### PR TITLE
Hint when no shortcut defined

### DIFF
--- a/ColorPicker/ColorPickerViewController.m
+++ b/ColorPicker/ColorPickerViewController.m
@@ -130,7 +130,13 @@
     float code = [userDefaults integerForKey:kUserDefaultsKeyCode];
     float modifier = [[userDefaults valueForKey:kUserDefaultsModifierKeys] longValue];
     
-    NSString *newLabel = [NSString stringWithFormat: @"Press %@%@ to copy color", SRStringForCocoaModifierFlags(modifier), SRStringForKeyCode(code)];
+	NSString *newLabel = nil;
+	if (code != -1) {
+		newLabel = [NSString stringWithFormat: @"Press %@%@ to copy color", SRStringForCocoaModifierFlags(modifier), SRStringForKeyCode(code)];
+	}
+	else {
+		newLabel = @"No shortcut defined";
+	}
     [shortcutLabel setStringValue:newLabel];
 }
 


### PR DESCRIPTION
Added a hint when no shortcut was defined (instead of displaying "Press (null) to ...").

![Bildschirmfoto 2013-04-09 um 10 03 33](https://f.cloud.github.com/assets/637549/355732/058dade4-a0ec-11e2-9477-d22942b1f8d7.png)
