### PR TITLE
Color palette support

### DIFF
--- a/Color Picker Pro.xcodeproj/project.pbxproj
+++ b/Color Picker Pro.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		55FE70C014210E9C007C8878 /* SRRecorderControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 55FE70BA14210E9C007C8878 /* SRRecorderControl.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		55FE70C114210E9C007C8878 /* SRValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 55FE70BC14210E9C007C8878 /* SRValidator.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		55FE70C314210ECE007C8878 /* ShortcutRecorder.strings in Resources */ = {isa = PBXBuildFile; fileRef = 55FE70C214210ECE007C8878 /* ShortcutRecorder.strings */; };
+		7901C23A1758C9600012C7E8 /* PaletteReader.m in Sources */ = {isa = PBXBuildFile; fileRef = 7901C2391758C9600012C7E8 /* PaletteReader.m */; };
+		7901C26B1758E7B50012C7E8 /* DTColor+HTML.m in Sources */ = {isa = PBXBuildFile; fileRef = 7901C26A1758E7B50012C7E8 /* DTColor+HTML.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -122,6 +124,10 @@
 		55FE70BB14210E9C007C8878 /* SRValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SRValidator.h; sourceTree = "<group>"; };
 		55FE70BC14210E9C007C8878 /* SRValidator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SRValidator.m; sourceTree = "<group>"; };
 		55FE70C214210ECE007C8878 /* ShortcutRecorder.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = ShortcutRecorder.strings; sourceTree = "<group>"; };
+		7901C2381758C9600012C7E8 /* PaletteReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PaletteReader.h; sourceTree = "<group>"; };
+		7901C2391758C9600012C7E8 /* PaletteReader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PaletteReader.m; sourceTree = "<group>"; };
+		7901C2691758E7AA0012C7E8 /* DTColor+HTML.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "DTColor+HTML.h"; sourceTree = "<group>"; };
+		7901C26A1758E7B50012C7E8 /* DTColor+HTML.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "DTColor+HTML.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -217,6 +223,8 @@
 		55D4EC8513FFF18D00D13344 /* ColorPicker */ = {
 			isa = PBXGroup;
 			children = (
+				7901C26A1758E7B50012C7E8 /* DTColor+HTML.m */,
+				7901C2691758E7AA0012C7E8 /* DTColor+HTML.h */,
 				55FE70B114210E87007C8878 /* ShortcutRecorder */,
 				555BB731141DE5C100AE82A9 /* Resources */,
 				55D4EC8613FFF18D00D13344 /* Supporting Files */,
@@ -245,6 +253,8 @@
 				55A883401415F8EE0076BB4A /* PreferencesController.m */,
 				55A8834E14162EF80076BB4A /* HelpController.h */,
 				55A8834F14162EF80076BB4A /* HelpController.m */,
+				7901C2381758C9600012C7E8 /* PaletteReader.h */,
+				7901C2391758C9600012C7E8 /* PaletteReader.m */,
 			);
 			path = ColorPicker;
 			sourceTree = "<group>";
@@ -373,6 +383,8 @@
 				55FE70BF14210E9C007C8878 /* SRRecorderCell.m in Sources */,
 				55FE70C014210E9C007C8878 /* SRRecorderControl.m in Sources */,
 				55FE70C114210E9C007C8878 /* SRValidator.m in Sources */,
+				7901C23A1758C9600012C7E8 /* PaletteReader.m in Sources */,
+				7901C26B1758E7B50012C7E8 /* DTColor+HTML.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ColorPicker/AppController.h
+++ b/ColorPicker/AppController.h
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "CustomWindow.h"
 #import "CustomStatusItem.h"
+#import "PaletteReader.h"
 
 @class ColorPickerView;
 @class RSLoginItems;
@@ -21,7 +22,7 @@
 @property (retain) NSTimer *updateTimer;
 @property (assign) BOOL updateMouseLocation;
 @property (assign) NSPoint mouseLocation;
-
+@property (retain) PaletteReader *paletteReader;
 - (void)toggleShowWindow;
 - (void)toggleShowWindowFromPoint:(NSPoint)point forceAnchoring:(BOOL)forceAnchoring;
 

--- a/ColorPicker/AppController.m
+++ b/ColorPicker/AppController.m
@@ -24,9 +24,13 @@
 - (void)awakeFromNib
 {
     self.loginItems = [[RSLoginItems alloc] init];
+    self.paletteReader = [[PaletteReader alloc] init];
+    
     
     // Count app runs
 	NSUserDefaults *defs = [NSUserDefaults standardUserDefaults];
+    [[self paletteReader] checkForColorPalette];
+    
 	int timesRun = (int)[defs integerForKey:kUserDefaultsKeyTimesRun];
 	if (!timesRun)
 		timesRun = 1;

--- a/ColorPicker/ColorPickerView.xib
+++ b/ColorPicker/ColorPickerView.xib
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">11B26</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1934</string>
-		<string key="IBDocument.AppKitVersion">1138</string>
-		<string key="IBDocument.HIToolboxVersion">566.00</string>
+		<int key="IBDocument.SystemTarget">1080</int>
+		<string key="IBDocument.SystemVersion">12D78</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">1934</string>
+			<string key="NS.object.0">3084</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
+			<string>NSButton</string>
+			<string>NSButtonCell</string>
+			<string>NSCustomObject</string>
 			<string>NSCustomView</string>
 			<string>NSTextField</string>
 			<string>NSTextFieldCell</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSButton</string>
 		</object>
 		<object class="NSArray" key="IBDocument.PluginDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -53,7 +53,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="436261778">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">B:</string>
 							<object class="NSFont" key="NSSupport" id="317214015">
@@ -82,6 +82,7 @@
 								</object>
 							</object>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="970020311">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -93,7 +94,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="254076750">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">S:</string>
 							<reference key="NSSupport" ref="317214015"/>
@@ -102,6 +103,7 @@
 							<reference key="NSBackgroundColor" ref="835640398"/>
 							<reference key="NSTextColor" ref="995519273"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="732523666">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -113,7 +115,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="937602091">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">H:</string>
 							<reference key="NSSupport" ref="317214015"/>
@@ -122,29 +124,29 @@
 							<reference key="NSBackgroundColor" ref="835640398"/>
 							<reference key="NSTextColor" ref="995519273"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
-					<object class="NSTextField" id="743952033">
+					<object class="NSTextField" id="468713529">
 						<reference key="NSNextResponder" ref="1005"/>
 						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{17, 20}, {299, 17}}</string>
+						<string key="NSFrame">{{225, 20}, {187, 17}}</string>
 						<reference key="NSSuperview" ref="1005"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="84200669"/>
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="918774296">
-							<int key="NSCellFlags">68288064</int>
+						<object class="NSTextFieldCell" key="NSCell" id="941578156">
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">4195328</int>
-							<string key="NSContents">shortcut help</string>
-							<object class="NSFont" key="NSSupport">
+							<string key="NSContents">palette color</string>
+							<object class="NSFont" key="NSSupport" id="864469702">
 								<string key="NSName">LucidaGrande</string>
 								<double key="NSSize">12</double>
 								<int key="NSfFlags">16</int>
 							</object>
 							<string key="NSCellIdentifier">_NS:3935</string>
-							<reference key="NSControlView" ref="743952033"/>
+							<reference key="NSControlView" ref="468713529"/>
 							<reference key="NSBackgroundColor" ref="835640398"/>
-							<object class="NSColor" key="NSTextColor">
+							<object class="NSColor" key="NSTextColor" id="328655919">
 								<int key="NSColorSpace">6</int>
 								<string key="NSCatalogName">System</string>
 								<string key="NSColorName">disabledControlTextColor</string>
@@ -154,6 +156,28 @@
 								</object>
 							</object>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
+					<object class="NSTextField" id="743952033">
+						<reference key="NSNextResponder" ref="1005"/>
+						<int key="NSvFlags">268</int>
+						<string key="NSFrame">{{17, 20}, {187, 17}}</string>
+						<reference key="NSSuperview" ref="1005"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="84200669"/>
+						<string key="NSReuseIdentifierKey">_NS:3935</string>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSTextFieldCell" key="NSCell" id="918774296">
+							<int key="NSCellFlags">68157504</int>
+							<int key="NSCellFlags2">4195328</int>
+							<string key="NSContents">shortcut help</string>
+							<reference key="NSSupport" ref="864469702"/>
+							<string key="NSCellIdentifier">_NS:3935</string>
+							<reference key="NSControlView" ref="743952033"/>
+							<reference key="NSBackgroundColor" ref="835640398"/>
+							<reference key="NSTextColor" ref="328655919"/>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSButton" id="84200669">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -161,17 +185,16 @@
 						<string key="NSFrame">{{452, 16}, {15, 15}}</string>
 						<reference key="NSSuperview" ref="1005"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<string key="NSReuseIdentifierKey">_NS:161</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="165729893">
-							<int key="NSCellFlags">67239424</int>
+							<int key="NSCellFlags">67108864</int>
 							<int key="NSCellFlags2">134250496</int>
 							<string key="NSContents"/>
 							<reference key="NSSupport" ref="317214015"/>
 							<string key="NSCellIdentifier">_NS:161</string>
 							<reference key="NSControlView" ref="84200669"/>
-							<int key="NSButtonFlags">-2042347265</int>
+							<int key="NSButtonFlags">-2042347520</int>
 							<int key="NSButtonFlags2">130</int>
 							<object class="NSCustomResource" key="NSNormalImage" id="649506712">
 								<string key="NSClassName">NSImage</string>
@@ -183,6 +206,7 @@
 							<int key="NSPeriodicDelay">200</int>
 							<int key="NSPeriodicInterval">25</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="560236450">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -194,7 +218,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="417131052">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">{}</string>
 							<reference key="NSSupport" ref="317214015"/>
@@ -203,6 +227,7 @@
 							<reference key="NSBackgroundColor" ref="835640398"/>
 							<reference key="NSTextColor" ref="995519273"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="18176214">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -214,7 +239,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="786509560">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">y:</string>
 							<reference key="NSSupport" ref="317214015"/>
@@ -223,6 +248,7 @@
 							<reference key="NSBackgroundColor" ref="835640398"/>
 							<reference key="NSTextColor" ref="995519273"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="961850033">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -234,7 +260,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="80349534">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">{}</string>
 							<reference key="NSSupport" ref="317214015"/>
@@ -243,6 +269,7 @@
 							<reference key="NSBackgroundColor" ref="835640398"/>
 							<reference key="NSTextColor" ref="995519273"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="880623890">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -254,7 +281,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="733687583">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">x:</string>
 							<reference key="NSSupport" ref="317214015"/>
@@ -263,6 +290,7 @@
 							<reference key="NSBackgroundColor" ref="835640398"/>
 							<reference key="NSTextColor" ref="995519273"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSCustomView" id="914187163">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -344,7 +372,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="1045060475">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">Label</string>
 							<reference key="NSSupport" ref="317214015"/>
@@ -353,6 +381,7 @@
 							<reference key="NSBackgroundColor" ref="835640398"/>
 							<reference key="NSTextColor" ref="995519273"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="577123685">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -364,7 +393,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="920256917">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">Label</string>
 							<reference key="NSSupport" ref="317214015"/>
@@ -373,6 +402,7 @@
 							<reference key="NSBackgroundColor" ref="835640398"/>
 							<reference key="NSTextColor" ref="995519273"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="1874621">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -384,7 +414,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="607328720">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">Label</string>
 							<reference key="NSSupport" ref="317214015"/>
@@ -393,6 +423,7 @@
 							<reference key="NSBackgroundColor" ref="835640398"/>
 							<reference key="NSTextColor" ref="995519273"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="25355851">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -404,7 +435,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="626810620">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">hex</string>
 							<reference key="NSSupport" ref="317214015"/>
@@ -413,6 +444,7 @@
 							<reference key="NSBackgroundColor" ref="835640398"/>
 							<reference key="NSTextColor" ref="995519273"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="644966">
 						<reference key="NSNextResponder" ref="1005"/>
@@ -424,7 +456,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3935</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="903783891">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">rgb</string>
 							<reference key="NSSupport" ref="317214015"/>
@@ -433,6 +465,7 @@
 							<reference key="NSBackgroundColor" ref="835640398"/>
 							<reference key="NSTextColor" ref="995519273"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 				</object>
 				<string key="NSFrameSize">{474, 248}</string>
@@ -605,6 +638,14 @@
 					</object>
 					<int key="connectionID">65</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">paletteColorName</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="468713529"/>
+					</object>
+					<int key="connectionID">69</int>
+				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<object class="NSArray" key="orderedObjects">
@@ -661,6 +702,7 @@
 							<reference ref="560236450"/>
 							<reference ref="84200669"/>
 							<reference ref="743952033"/>
+							<reference ref="468713529"/>
 						</object>
 						<reference key="parent" ref="1002"/>
 					</object>
@@ -898,6 +940,20 @@
 						<reference key="object" ref="626810620"/>
 						<reference key="parent" ref="25355851"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">66</int>
+						<reference key="object" ref="468713529"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="941578156"/>
+						</object>
+						<reference key="parent" ref="1005"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">67</int>
+						<reference key="object" ref="941578156"/>
+						<reference key="parent" ref="468713529"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -943,9 +999,13 @@
 					<string>58.IBPluginDependency</string>
 					<string>61.IBPluginDependency</string>
 					<string>62.IBPluginDependency</string>
+					<string>66.IBPluginDependency</string>
+					<string>67.IBPluginDependency</string>
 				</object>
-				<object class="NSMutableArray" key="dict.values">
+				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -999,7 +1059,7 @@
 				<reference key="dict.values" ref="1002"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">65</int>
+			<int key="maxID">69</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -1048,13 +1108,14 @@
 							<string>colorPreview</string>
 							<string>hexText</string>
 							<string>hueText</string>
+							<string>paletteColorName</string>
 							<string>rgbText</string>
 							<string>saturationText</string>
 							<string>shortcutLabel</string>
 							<string>x</string>
 							<string>y</string>
 						</object>
-						<object class="NSMutableArray" key="dict.values">
+						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>NSTextField</string>
 							<string>ColorHistoryView</string>
@@ -1064,6 +1125,7 @@
 							<string>ColorHistoryView</string>
 							<string>ColorPickerPreview</string>
 							<string>ColorHistoryView</string>
+							<string>NSTextField</string>
 							<string>NSTextField</string>
 							<string>NSTextField</string>
 							<string>NSTextField</string>
@@ -1087,13 +1149,14 @@
 							<string>colorPreview</string>
 							<string>hexText</string>
 							<string>hueText</string>
+							<string>paletteColorName</string>
 							<string>rgbText</string>
 							<string>saturationText</string>
 							<string>shortcutLabel</string>
 							<string>x</string>
 							<string>y</string>
 						</object>
-						<object class="NSMutableArray" key="dict.values">
+						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<object class="IBToOneOutletInfo">
 								<string key="name">brightnessText</string>
@@ -1133,6 +1196,10 @@
 							</object>
 							<object class="IBToOneOutletInfo">
 								<string key="name">hueText</string>
+								<string key="candidateClassName">NSTextField</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">paletteColorName</string>
 								<string key="candidateClassName">NSTextField</string>
 							</object>
 							<object class="IBToOneOutletInfo">

--- a/ColorPicker/ColorPickerViewController.h
+++ b/ColorPicker/ColorPickerViewController.h
@@ -26,6 +26,8 @@
 @property (retain) IBOutlet NSTextField *x;
 @property (retain) IBOutlet NSTextField *y;
 
+@property (retain) IBOutlet NSTextField *paletteColorName;
+
 @property (retain) IBOutlet ColorHistoryView *colorHistoryView1;
 @property (retain) IBOutlet ColorHistoryView *colorHistoryView2;
 @property (retain) IBOutlet ColorHistoryView *colorHistoryView3;

--- a/ColorPicker/ColorPickerViewController.m
+++ b/ColorPicker/ColorPickerViewController.m
@@ -29,6 +29,7 @@
 @synthesize updateColorsHistory;
 @synthesize colorHistoryView1, colorHistoryView2, colorHistoryView3, colorHistoryView4, colorHistoryView5;
 @synthesize x, y;
+@synthesize paletteColorName;
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
@@ -101,6 +102,8 @@
     
     [x setStringValue:[NSString stringWithFormat:@"%.f", mouseLocation.x]];
     [y setStringValue:[NSString stringWithFormat:@"%.f", mouseLocation.y]];
+    
+    [paletteColorName setStringValue: [[appController paletteReader] getColorNameFor:currentColor]];
     
     [self updateHistoryView];
 }

--- a/ColorPicker/Constants.h
+++ b/ColorPicker/Constants.h
@@ -12,6 +12,8 @@
 #define kUserDefaultsKeyCode @"kUserDefaultsKeyCode"
 #define kUserDefaultsModifierKeys @"kUserDefaultsModifierKeys"
 
+#define kUserDefaultsPaletteUrl @"paletteURL"
+
 typedef enum {
     kFormatHEX,
     kFormatRGB,

--- a/ColorPicker/DTColor+HTML.h
+++ b/ColorPicker/DTColor+HTML.h
@@ -1,0 +1,65 @@
+//
+//  DTColor+HTML.h
+//  CoreTextExtensions
+//
+
+//  Cocoanetics is the original author.
+
+//  Created by Oliver Drobnik on 1/9/11.
+//  Copyright 2011 Drobnik.com. All rights reserved.
+//
+
+typedef NSColor DTColor;
+
+@interface NSString (HTML);
+
+@end
+
+
+/**
+ Methods used to work with HTML representations of colors.
+ */
+@interface NSColor (HTML)
+
+
+/**
+ Takes a CSS color string ('333', 'F9FFF9'), determines the RGB values used, and returns an NSColor object of that color.
+ For each part of the RGB color those numbers for that color are converted to a number using a category on NSString. Then that number is divided by the maximum value, 15 for 3 character strings and 255 for 6 character strings, making the color a percentage and within the range 0.0 and 1.0 that NSColor uses.
+ @param hex A CSS hexadecimal color string of length 6 or 3.
+ @returns An NSColor object generated from the hexadecimal color string with alpha 1.0.
+ */
++ (NSColor *)colorWithHexString:(NSString *)hex;
+
+
+/**
+ Takes an English string representing a color and maps it to a numeric RGB value as declared by the HTML and CSS specifications (see http://www.w3schools.com/html/html_colornames.asp). Also accepts CSS `#` hexadecimal colors, `rgba`, and `rgb` and does the right thing returning a corresponding NSColor.
+ If a color begins with a `#` we know that it is a hexadecimal color and send it to colorWithHexString:. If the string is an `rgba()` color declaration the comma delimited r, g, b, and a values are made into percentages and then made into an NSColor which is returned. If the string is an `rgb()` color declaration the same process happens except with an alpha of 1.0.
+ The last case is that the color string is not a numeric declaration `#`, nor a `rgba` or `rgb` declaration so the CSS color value matching the English string is found in a lookup dictionary and then passed to colorWithHexString: which will make an NSColor out of the hexadecimal string.
+ @param name The CSS color string that we want to map from a name into an RGB color.
+ @returns An NSColor object representing the name parameter as numeric values declared by the HTML and CSS specifications, a `rgba()` color, or a `rgb()` color.
+ */
++ (NSColor *)colorWithHTMLName:(NSString *)name;
+
+
+/**
+ Return a string hexadecimal representation of this NSColor. Splits the color into components with CGColor methods, re-maps them from percentages in the range 0-255, and returns the RGB color (alpha is stripped) in a six character string.
+ @returns A CSS hexadecimal NSString specifying this NSColor.
+ */
+- (NSString *)htmlHexString;
+
+
+/**
+ Converts a CGColorRef into an NSColor by placing each component into an NSColor and pending on the component count to return a grayscale or rgb color. If there are not 2 (grayscale) or 4 (rgba) components the color is from an unsupported color space and nil is returned.
+ @param cgColor The CGColorRef to convert
+ @returns An NSColor of this CGColorRef
+ */
++ (NSColor *)colorWithCGColor:(CGColorRef)cgColor;
+
+
+/**
+ Pass through method. This is used for unit testing
+ @returns This color. Returns self.
+ */
+- (NSColor *)CGColor;
+
+@end

--- a/ColorPicker/DTColor+HTML.m
+++ b/ColorPicker/DTColor+HTML.m
@@ -1,0 +1,287 @@
+//
+//  DTColor+HTML.m
+//  CoreTextExtensions
+
+//  Cocoanetics is the original author.
+
+//  Created by Oliver Drobnik on 1/9/11.
+//  Copyright 2011 Drobnik.com. All rights reserved.
+//
+
+
+#import "DTColor+HTML.h"
+
+static NSDictionary *colorLookup = nil;
+@implementation NSString (HTML)
+
+- (NSUInteger)integerValueFromHex
+{
+	NSUInteger result = 0;
+	sscanf([self UTF8String], "%x", &result);
+	return result;
+}
+
+@end
+@implementation NSColor (HTML)
+
++ (NSColor *)colorWithHexString:(NSString *)hex
+{
+	if ([hex length]!=6 && [hex length]!=3)
+	{
+		return nil;
+	}
+    
+	NSUInteger digits = [hex length]/3;
+	CGFloat maxValue = (digits==1)?15.0:255.0;
+    
+	CGFloat red = [[hex substringWithRange:NSMakeRange(0, digits)] integerValueFromHex]/maxValue;
+	CGFloat green = [[hex substringWithRange:NSMakeRange(digits, digits)] integerValueFromHex]/maxValue;
+	CGFloat blue = [[hex substringWithRange:NSMakeRange(2*digits, digits)] integerValueFromHex]/maxValue;
+    
+	return [NSColor colorWithDeviceRed:red green:green blue:blue alpha:1.0];
+}
+- (NSUInteger)integerValueFromHex
+{
+    NSScanner *scanner = [NSScanner scannerWithString:self];
+    unsigned int result = 0;
+    [scanner scanHexInt: &result];
+    
+    return result;
+}
+
+// Source: http://www.w3schools.com/html/html_colornames.asp
++ (NSColor *)colorWithHTMLName:(NSString *)name
+{
+	if ([name hasPrefix:@"#"])
+	{
+		return [NSColor colorWithHexString:[name substringFromIndex:1]];
+	}
+    
+	if ([name hasPrefix:@"rgba"]) {
+		NSString *rgbaName = [name stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"rgba() "]];
+		NSArray *rgba = [rgbaName componentsSeparatedByString:@","];
+        
+		if ([rgba count] != 4) {
+			// Incorrect syntax
+			return nil;
+		}
+        
+		return [NSColor colorWithDeviceRed:[[rgba objectAtIndex:0] floatValue] / 255
+                                     green:[[rgba objectAtIndex:1] floatValue] / 255
+                                      blue:[[rgba objectAtIndex:2] floatValue] / 255
+                                     alpha:[[rgba objectAtIndex:3] floatValue]];
+	}
+    
+	if([name hasPrefix:@"rgb"])
+	{
+		NSString * rgbName = [name stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"rbg() "]];
+		NSArray* rbg = [rgbName componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@","]];
+		if ([rbg count] != 3) {
+			// Incorrect syntax
+			return nil;
+		}
+		return [NSColor colorWithDeviceRed:[[rbg objectAtIndex:0]floatValue]/255
+                                     green:[[rbg objectAtIndex:1]floatValue] /255
+                                      blue:[[rbg objectAtIndex:2]floatValue] /255
+                                     alpha:1.0];
+	}
+    
+	static dispatch_once_t predicate;
+	dispatch_once(&predicate, ^{
+		colorLookup = [[NSDictionary alloc] initWithObjectsAndKeys:
+                       @"F0F8FF", @"aliceblue",
+                       @"FAEBD7", @"antiquewhite",
+                       @"00FFFF", @"aqua",
+                       @"7FFFD4", @"aquamarine",
+                       @"F0FFFF", @"azure",
+                       @"F5F5DC", @"beige",
+                       @"FFE4C4", @"bisque",
+                       @"000000", @"black",
+                       @"FFEBCD", @"blanchedalmond",
+                       @"0000FF", @"blue",
+                       @"8A2BE2", @"blueviolet",
+                       @"A52A2A", @"brown",
+                       @"DEB887", @"burlywood",
+                       @"5F9EA0", @"cadetblue",
+                       @"7FFF00", @"chartreuse",
+                       @"D2691E", @"chocolate",
+                       @"FF7F50", @"coral",
+                       @"6495ED", @"cornflowerblue",
+                       @"FFF8DC", @"cornsilk",
+                       @"DC143C", @"crimson",
+                       @"00FFFF", @"cyan",
+                       @"00008B", @"darkblue",
+                       @"008B8B", @"darkcyan",
+                       @"B8860B", @"darkgoldenrod",
+                       @"A9A9A9", @"darkgray",
+                       @"A9A9A9", @"darkgrey",
+                       @"006400", @"darkgreen",
+                       @"BDB76B", @"darkkhaki",
+                       @"8B008B", @"darkmagenta",
+                       @"556B2F", @"darkolivegreen",
+                       @"FF8C00", @"darkorange",
+                       @"9932CC", @"darkorchid",
+                       @"8B0000", @"darkred",
+                       @"E9967A", @"darksalmon",
+                       @"8FBC8F", @"darkseagreen",
+                       @"483D8B", @"darkslateblue",
+                       @"2F4F4F", @"darkslategray",
+                       @"2F4F4F", @"darkslategrey",
+                       @"00CED1", @"darkturquoise",
+                       @"9400D3", @"darkviolet",
+                       @"FF1493", @"deeppink",
+                       @"00BFFF", @"deepskyblue",
+                       @"696969", @"dimgray",
+                       @"696969", @"dimgrey",
+                       @"1E90FF", @"dodgerblue",
+                       @"B22222", @"firebrick",
+                       @"FFFAF0", @"floralwhite",
+                       @"228B22", @"forestgreen",
+                       @"FF00FF", @"fuchsia",
+                       @"DCDCDC", @"gainsboro",
+                       @"F8F8FF", @"ghostwhite",
+                       @"FFD700", @"gold",
+                       @"DAA520", @"goldenrod",
+                       @"808080", @"gray",
+                       @"808080", @"grey",
+                       @"008000", @"green",
+                       @"ADFF2F", @"greenyellow",
+                       @"F0FFF0", @"honeydew",
+                       @"FF69B4", @"hotpink",
+                       @"CD5C5C", @"indianred",
+                       @"4B0082", @"indigo",
+                       @"FFFFF0", @"ivory",
+                       @"F0E68C", @"khaki",
+                       @"E6E6FA", @"lavender",
+                       @"FFF0F5", @"lavenderblush",
+                       @"7CFC00", @"lawngreen",
+                       @"FFFACD", @"lemonchiffon",
+                       @"ADD8E6", @"lightblue",
+                       @"F08080", @"lightcoral",
+                       @"E0FFFF", @"lightcyan",
+                       @"FAFAD2", @"lightgoldenrodyellow",
+                       @"D3D3D3", @"lightgray",
+                       @"D3D3D3", @"lightgrey",
+                       @"90EE90", @"lightgreen",
+                       @"FFB6C1", @"lightpink",
+                       @"FFA07A", @"lightsalmon",
+                       @"20B2AA", @"lightseagreen",
+                       @"87CEFA", @"lightskyblue",
+                       @"778899", @"lightslategray",
+                       @"778899", @"lightslategrey",
+                       @"B0C4DE", @"lightsteelblue",
+                       @"FFFFE0", @"lightyellow",
+                       @"00FF00", @"lime",
+                       @"32CD32", @"limegreen",
+                       @"FAF0E6", @"linen",
+                       @"FF00FF", @"magenta",
+                       @"800000", @"maroon",
+                       @"66CDAA", @"mediumaquamarine",
+                       @"0000CD", @"mediumblue",
+                       @"BA55D3", @"mediumorchid",
+                       @"9370D8", @"mediumpurple",
+                       @"3CB371", @"mediumseagreen",
+                       @"7B68EE", @"mediumslateblue",
+                       @"00FA9A", @"mediumspringgreen",
+                       @"48D1CC", @"mediumturquoise",
+                       @"C71585", @"mediumvioletred",
+                       @"191970", @"midnightblue",
+                       @"F5FFFA", @"mintcream",
+                       @"FFE4E1", @"mistyrose",
+                       @"FFE4B5", @"moccasin",
+                       @"FFDEAD", @"navajowhite",
+                       @"000080", @"navy",
+                       @"FDF5E6", @"oldlace",
+                       @"808000", @"olive",
+                       @"6B8E23", @"olivedrab",
+                       @"FFA500", @"orange",
+                       @"FF4500", @"orangered",
+                       @"DA70D6", @"orchid",
+                       @"EEE8AA", @"palegoldenrod",
+                       @"98FB98", @"palegreen",
+                       @"AFEEEE", @"paleturquoise",
+                       @"D87093", @"palevioletred",
+                       @"FFEFD5", @"papayawhip",
+                       @"FFDAB9", @"peachpuff",
+                       @"CD853F", @"peru",
+                       @"FFC0CB", @"pink",
+                       @"DDA0DD", @"plum",
+                       @"B0E0E6", @"powderblue",
+                       @"800080", @"purple",
+                       @"FF0000", @"red",
+                       @"BC8F8F", @"rosybrown",
+                       @"4169E1", @"royalblue",
+                       @"8B4513", @"saddlebrown",
+                       @"FA8072", @"salmon",
+                       @"F4A460", @"sandybrown",
+                       @"2E8B57", @"seagreen",
+                       @"FFF5EE", @"seashell",
+                       @"A0522D", @"sienna",
+                       @"C0C0C0", @"silver",
+                       @"87CEEB", @"skyblue",
+                       @"6A5ACD", @"slateblue",
+                       @"708090", @"slategray",
+                       @"708090", @"slategrey",
+                       @"FFFAFA", @"snow",
+                       @"00FF7F", @"springgreen",
+                       @"4682B4", @"steelblue",
+                       @"D2B48C", @"tan",
+                       @"008080", @"teal",
+                       @"D8BFD8", @"thistle",
+                       @"FF6347", @"tomato",
+                       @"40E0D0", @"turquoise",
+                       @"EE82EE", @"violet",
+                       @"F5DEB3", @"wheat",
+                       @"FFFFFF", @"white",
+                       @"F5F5F5", @"whitesmoke",
+                       @"FFFF00", @"yellow",
+                       @"9ACD32", @"yellowgreen",
+                       nil];
+	});
+    
+	NSString *hexString = [colorLookup objectForKey:[name lowercaseString]];
+    
+	return [NSColor colorWithHexString:hexString];
+}
+
+- (NSString *)htmlHexString
+{
+	CGFloat red = self.redComponent;
+	CGFloat blue = self.blueComponent;
+	CGFloat green = self.greenComponent;
+    
+	static NSString *stringFormat = @"%02x%02x%02x";
+    
+	return [NSString stringWithFormat:stringFormat, (NSUInteger)(red * (CGFloat)255),
+            (NSUInteger)(green * (CGFloat)255), (NSUInteger)(blue * (CGFloat)255)];
+}
+
+
++ (NSColor *)colorWithCGColor:(CGColorRef)cgColor
+{
+	size_t count = CGColorGetNumberOfComponents(cgColor);
+	const CGFloat *components = CGColorGetComponents(cgColor);
+    
+	// Grayscale
+	if (count == 2)
+	{
+		return [NSColor colorWithDeviceWhite:components[0] alpha:components[1]];
+	}
+    
+	// RGB
+	else if (count == 4)
+	{
+		return [NSColor colorWithDeviceRed:components[0] green:components[1] blue:components[2] alpha:components[3]];
+	}
+    
+	// neigher grayscale nor rgba
+	return nil;
+}
+
+// pass through
+- (NSColor *)CGColor
+{
+	return self;
+}
+
+@end

--- a/ColorPicker/PaletteReader.h
+++ b/ColorPicker/PaletteReader.h
@@ -1,0 +1,11 @@
+
+#import <Foundation/Foundation.h>
+
+@interface PaletteReader : NSObject
+
+- (NSString*) getColorNameFor: (NSColor*) color;
+- (BOOL) hasColorPalette;
+- (void) loadColorPaletteAt: (NSURL*) url;
+- (float) distanceBetween: (NSColor*)crl andColor: (NSColor* )crll;
+- (void) checkForColorPalette;
+@end

--- a/ColorPicker/PaletteReader.m
+++ b/ColorPicker/PaletteReader.m
@@ -1,0 +1,168 @@
+//
+//  PaletteReader.m
+//  Color Picker Pro
+//
+//  Created by Mehdi Abedanzadeh on 5/31/13.
+//  Copyright (c) 2013 DibiStore. All rights reserved.
+//
+
+#import "PaletteReader.h"
+#import "DTColor+HTML.h"
+
+@implementation PaletteReader
+NSDictionary *colorPalette = NULL;
+#pragma mark - file handling
+
+- (BOOL) hasColorPalette {
+    return colorPalette != NULL;
+}
+- (void) checkForColorPalette {
+    NSURL * url = [[NSUserDefaults standardUserDefaults] URLForKey:kUserDefaultsPaletteUrl];
+    if (url) {
+        [self loadColorPaletteAt:url];
+    }
+}
+- (void) loadColorPaletteAt: (NSURL*) url {
+    
+    NSData *data;
+    
+    BOOL success = FALSE;
+    
+    //pass the data to the right parser
+    if ([[url pathExtension] isEqualToString:@"less"]) {
+        data = [NSData dataWithContentsOfURL:url];
+        success= [self parseLessData:data];
+    } /*if ([[url pathExtension] isEqualToString:@"aco"]) {}*/
+    
+    if (success) {
+        [[NSUserDefaults standardUserDefaults] setURL:url forKey:kUserDefaultsPaletteUrl];
+    } else {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kUserDefaultsPaletteUrl];
+    }
+}
+
+
+#pragma mark - color handling
+
+
+- (float) distanceBetween: (NSColor*) first andColor: (NSColor*) second {
+    return sqrtf(powf((first.redComponent - second.redComponent), 2) + powf((first.greenComponent - second.greenComponent), 2) + powf((first.blueComponent - second.blueComponent), 2));
+}
+
+- (NSString*) getColorNameFor: (NSColor*) color {
+    if (![self hasColorPalette]) {
+        return @"";
+    }
+    NSArray *keyArray =  [colorPalette allKeys];
+    NSColor *eachcolor;
+    NSInteger count = [keyArray count];
+    float distance;
+    NSString* key;
+    float threshold = 10;
+    NSString *closestKey;
+    for (int i=0; i < count; i++) {
+        key = [keyArray objectAtIndex:i];
+        eachcolor = [colorPalette objectForKey:key];
+        distance = [self distanceBetween:eachcolor andColor:color];
+        if (distance == 0) {
+            return key;
+        }
+        if (threshold > distance) {
+            closestKey = key;
+            threshold = distance;
+        }
+    }
+    if (closestKey) {
+        return [NSString stringWithFormat:@"%@ (%.02f)", closestKey, threshold];
+    }
+    return @"";
+}
+#pragma mark - lessparser
+/*
+ extremely basic parser.
+ only supports less files filled with colors. anything else will cause the file to be unreadable.
+ less variables are not supported, nor color calculations.
+ farther contributions are welcome.
+ 
+ double dash comments are accepted.
+ example:
+/////////////
+
+ @my-precious-color: red;
+ @my-red: rgb(255,0,0);
+ 
+/////////////
+ 
+ */
+- (BOOL) parseLessData:(NSData*)data {
+    NSString *output = [[[NSString alloc]initWithData:data
+                                             encoding:NSUTF8StringEncoding]
+                        stringByReplacingOccurrencesOfString:@" " withString:@""];
+    
+    BOOL insideComment = FALSE;
+    
+    NSMutableDictionary* mutable = [[NSMutableDictionary alloc] init];
+    BOOL success = FALSE;
+    BOOL isBreak = FALSE;
+    int lineStart = 0;
+    unichar chara;
+    
+    for (int i = 0; i < output.length; i++) {
+        chara = [output characterAtIndex:i];
+        isBreak = chara == '\n' || [output characterAtIndex:i] == '\r';
+        if (insideComment && isBreak) {
+            lineStart = i;
+            insideComment = FALSE;
+            continue;
+        }
+        
+        if (chara == '/' && output.length > i+1 && [output characterAtIndex:i+1] == '/') {
+            success = [self processLessLine:[output substringWithRange:NSMakeRange(lineStart, i - lineStart)] to:mutable] || success;
+            insideComment = TRUE;
+            i++;
+            continue;
+        }
+        if (chara == ';' && !insideComment) {
+            success = [self processLessLine:[output substringWithRange:NSMakeRange(lineStart, i - lineStart)] to:mutable] || success;
+            lineStart = i;
+            continue;
+        }
+    }
+    if (success) {
+        colorPalette = [NSDictionary dictionaryWithDictionary:mutable];
+        return TRUE;
+    } else {
+        return FALSE;
+    }
+
+}
+
+- (BOOL) processLessLine: (NSString*) line to: (NSMutableDictionary*) dic{
+    NSString *name;
+    NSString *colorString;
+    NSColor *color;
+    NSArray *parts;
+    line = [line stringByReplacingOccurrencesOfString:@";" withString:@""];
+    line = [line stringByReplacingOccurrencesOfString:@"\r" withString:@""];
+    line = [line stringByReplacingOccurrencesOfString:@"\n" withString:@""];
+    if (line.length < 4) {
+        return FALSE;
+    }
+    parts = [line componentsSeparatedByString:@":"];
+    name = [parts objectAtIndex:0];
+    colorString = [parts objectAtIndex:1];
+    color = [NSColor colorWithHTMLName:colorString];
+    if (color) {
+        [dic setObject:color forKey:name];
+    }
+    if (!color) {
+        color = [NSColor colorWithHexString:colorString];
+    }
+    if (color) {
+        [dic setObject:color forKey:name];
+        return TRUE;
+    }
+    return FALSE;
+}
+
+@end

--- a/ColorPicker/PreferencesController.h
+++ b/ColorPicker/PreferencesController.h
@@ -24,6 +24,7 @@ typedef enum {
 
 @property (strong) IBOutlet NSPopUpButton *defaultFormat;
 @property (strong) IBOutlet NSButton *openAtLogin;
+@property (strong) IBOutlet NSButton *palettePicker;
 @property (strong) IBOutlet NSButton *showColorPreview;
 @property (retain) RSLoginItems *loginItems;
 @property (retain) CustomStatusItem *statusItemView;
@@ -31,4 +32,5 @@ typedef enum {
 @property (strong) IBOutlet SRRecorderControl *recorderView;
 
 - (IBAction)controllerChanged:(id)sender;
+- (IBAction)paletteFileOpener:(id)sender;
 @end

--- a/ColorPicker/PreferencesController.m
+++ b/ColorPicker/PreferencesController.m
@@ -43,14 +43,42 @@
     [defaultFormat selectItemAtIndex:[userDefaults integerForKey:kUserDefaultsDefaultFormat]];
     openAtLogin.state = [userDefaults boolForKey:kUserDefaultsKeyStartAtLogin];
     showColorPreview.state = [userDefaults boolForKey:kUserDefaultsShowMenuBarPreview];
-    
     // Set the default shortcut text
-
+    [self setFilePickerTitle];
+ 
     NSInteger code = [[userDefaults valueForKey:kUserDefaultsKeyCode] longValue];
     NSInteger flags = [[userDefaults valueForKey:kUserDefaultsModifierKeys] longValue];
     
     SRRecorderCell *cell = (SRRecorderCell *)[recorderView cell];
     cell.keyCombo = SRMakeKeyCombo(code, flags);
+}
+
+- (void)paletteFileOpener:(id)sender {
+    NSOpenPanel *openpanel = [NSOpenPanel openPanel];
+    openpanel.canChooseFiles = TRUE;
+    [openpanel setAllowedFileTypes:[NSArray arrayWithObjects:@"LESS", nil]];
+//    [openpanel setAllowedFileTypes:[NSImage imageFileTypes]];
+    openpanel.canCreateDirectories = FALSE;
+    [openpanel beginWithCompletionHandler: ^(NSInteger result){
+        if (result == NSFileHandlingPanelOKButton) {
+            NSURL*  theDoc = [[openpanel URLs] objectAtIndex:0];
+            [appController.paletteReader loadColorPaletteAt:theDoc];
+            // Open  the document.
+            [self setFilePickerTitle];           
+        }
+        
+    }];
+}
+
+- (void) setFilePickerTitle {
+    //file might have been broken or empty, therefore we check again
+    NSURL *url = [[NSUserDefaults standardUserDefaults] URLForKey:kUserDefaultsPaletteUrl];
+    if (url) {
+        NSString* lastComponent = [url lastPathComponent];
+        [[self palettePicker] setTitle: lastComponent];
+    } else {
+        [[self palettePicker] setTitle: @"Browse"];
+    }
 }
 
 - (IBAction)controllerChanged:(id)sender {

--- a/ColorPicker/PreferencesController.xib
+++ b/ColorPicker/PreferencesController.xib
@@ -2,13 +2,13 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1080</int>
-		<string key="IBDocument.SystemVersion">12C2034</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2844</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
+		<string key="IBDocument.SystemVersion">12D78</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">2844</string>
+			<string key="NS.object.0">3084</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
 			<string>NSBox</string>
@@ -45,7 +45,7 @@
 			<object class="NSWindowTemplate" id="638456603">
 				<int key="NSWindowStyleMask">23</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{-1724, 236}, {378, 272}}</string>
+				<string key="NSWindowRect">{{-1724, 236}, {378, 329}}</string>
 				<int key="NSWTFlags">-1535638528</int>
 				<string key="NSWindowTitle">Preferences</string>
 				<string key="NSWindowClass">NSPanel</string>
@@ -58,9 +58,8 @@
 						<object class="NSTextField" id="345060115">
 							<reference key="NSNextResponder" ref="579521538"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{75, 206}, {136, 17}}</string>
+							<string key="NSFrame">{{75, 263}, {136, 17}}</string>
 							<reference key="NSSuperview" ref="579521538"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="953804436"/>
 							<string key="NSReuseIdentifierKey">_NS:3935</string>
 							<bool key="NSEnabled">YES</bool>
@@ -99,9 +98,8 @@
 						<object class="NSButton" id="259229107">
 							<reference key="NSNextResponder" ref="579521538"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{76, 110}, {284, 18}}</string>
+							<string key="NSFrame">{{76, 167}, {284, 18}}</string>
 							<reference key="NSSuperview" ref="579521538"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="632430646"/>
 							<string key="NSReuseIdentifierKey">_NS:238</string>
 							<bool key="NSEnabled">YES</bool>
@@ -131,9 +129,8 @@
 						<object class="NSButton" id="632430646">
 							<reference key="NSNextResponder" ref="579521538"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{76, 82}, {280, 18}}</string>
+							<string key="NSFrame">{{76, 139}, {280, 18}}</string>
 							<reference key="NSSuperview" ref="579521538"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="670204656"/>
 							<string key="NSReuseIdentifierKey">_NS:238</string>
 							<bool key="NSEnabled">YES</bool>
@@ -158,9 +155,8 @@
 						<object class="NSTextField" id="673984933">
 							<reference key="NSNextResponder" ref="579521538"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{17, 235}, {56, 17}}</string>
+							<string key="NSFrame">{{17, 292}, {56, 17}}</string>
 							<reference key="NSSuperview" ref="579521538"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="890912462"/>
 							<string key="NSReuseIdentifierKey">_NS:3935</string>
 							<bool key="NSEnabled">YES</bool>
@@ -179,9 +175,8 @@
 						<object class="NSTextField" id="608284740">
 							<reference key="NSNextResponder" ref="579521538"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{17, 143}, {53, 17}}</string>
+							<string key="NSFrame">{{17, 200}, {53, 17}}</string>
 							<reference key="NSSuperview" ref="579521538"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="1060005640"/>
 							<string key="NSReuseIdentifierKey">_NS:3935</string>
 							<bool key="NSEnabled">YES</bool>
@@ -200,9 +195,8 @@
 						<object class="NSTextField" id="670204656">
 							<reference key="NSNextResponder" ref="579521538"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{75, 39}, {61, 17}}</string>
+							<string key="NSFrame">{{75, 96}, {61, 17}}</string>
 							<reference key="NSSuperview" ref="579521538"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="621850563"/>
 							<string key="NSReuseIdentifierKey">_NS:3935</string>
 							<bool key="NSEnabled">YES</bool>
@@ -221,9 +215,8 @@
 						<object class="NSBox" id="890912462">
 							<reference key="NSNextResponder" ref="579521538"/>
 							<int key="NSvFlags">12</int>
-							<string key="NSFrame">{{78, 240}, {276, 5}}</string>
+							<string key="NSFrame">{{78, 297}, {276, 5}}</string>
 							<reference key="NSSuperview" ref="579521538"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="345060115"/>
 							<string key="NSReuseIdentifierKey">_NS:1458</string>
 							<string key="NSOffsets">{0, 0}</string>
@@ -254,10 +247,53 @@
 						<object class="NSBox" id="1060005640">
 							<reference key="NSNextResponder" ref="579521538"/>
 							<int key="NSvFlags">12</int>
-							<string key="NSFrame">{{78, 147}, {276, 5}}</string>
+							<string key="NSFrame">{{78, 204}, {276, 5}}</string>
 							<reference key="NSSuperview" ref="579521538"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="259229107"/>
+							<string key="NSReuseIdentifierKey">_NS:1458</string>
+							<string key="NSOffsets">{0, 0}</string>
+							<object class="NSTextFieldCell" key="NSTitleCell">
+								<int key="NSCellFlags">67108864</int>
+								<int key="NSCellFlags2">0</int>
+								<string key="NSContents">Box</string>
+								<reference key="NSSupport" ref="473291212"/>
+								<reference key="NSBackgroundColor" ref="416095"/>
+								<object class="NSColor" key="NSTextColor">
+									<int key="NSColorSpace">3</int>
+									<bytes key="NSWhite">MCAwLjgwMDAwMDAxMTkAA</bytes>
+								</object>
+							</object>
+							<int key="NSBorderType">3</int>
+							<int key="NSBoxType">2</int>
+							<int key="NSTitlePosition">0</int>
+							<bool key="NSTransparent">NO</bool>
+						</object>
+						<object class="NSTextField" id="452078279">
+							<reference key="NSNextResponder" ref="579521538"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{17, 70}, {47, 17}}</string>
+							<reference key="NSSuperview" ref="579521538"/>
+							<reference key="NSNextKeyView" ref="740933624"/>
+							<string key="NSReuseIdentifierKey">_NS:3935</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="957168895">
+								<int key="NSCellFlags">68157504</int>
+								<int key="NSCellFlags2">272630784</int>
+								<string key="NSContents">Palette</string>
+								<reference key="NSSupport" ref="473291212"/>
+								<string key="NSCellIdentifier">_NS:3935</string>
+								<reference key="NSControlView" ref="452078279"/>
+								<reference key="NSBackgroundColor" ref="101258147"/>
+								<reference key="NSTextColor" ref="563040958"/>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
+						<object class="NSBox" id="740933624">
+							<reference key="NSNextResponder" ref="579521538"/>
+							<int key="NSvFlags">12</int>
+							<string key="NSFrame">{{78, 74}, {276, 5}}</string>
+							<reference key="NSSuperview" ref="579521538"/>
+							<reference key="NSNextKeyView" ref="293850217"/>
 							<string key="NSReuseIdentifierKey">_NS:1458</string>
 							<string key="NSOffsets">{0, 0}</string>
 							<object class="NSTextFieldCell" key="NSTitleCell">
@@ -279,9 +315,8 @@
 						<object class="NSPopUpButton" id="953804436">
 							<reference key="NSNextResponder" ref="579521538"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{225, 200}, {100, 26}}</string>
+							<string key="NSFrame">{{225, 257}, {100, 26}}</string>
 							<reference key="NSSuperview" ref="579521538"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="139660187"/>
 							<string key="NSReuseIdentifierKey">_NS:179</string>
 							<bool key="NSEnabled">YES</bool>
@@ -395,9 +430,8 @@
 						<object class="NSTextField" id="139660187">
 							<reference key="NSNextResponder" ref="579521538"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{75, 170}, {407, 17}}</string>
+							<string key="NSFrame">{{75, 227}, {407, 17}}</string>
 							<reference key="NSSuperview" ref="579521538"/>
-							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="608284740"/>
 							<string key="NSReuseIdentifierKey">_NS:3935</string>
 							<bool key="NSEnabled">YES</bool>
@@ -420,28 +454,52 @@
 						<object class="NSCustomView" id="621850563">
 							<reference key="NSNextResponder" ref="579521538"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{148, 36}, {149, 22}}</string>
+							<string key="NSFrame">{{148, 93}, {149, 22}}</string>
 							<reference key="NSSuperview" ref="579521538"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView"/>
+							<reference key="NSNextKeyView" ref="452078279"/>
 							<string key="NSReuseIdentifierKey">_NS:1192</string>
 							<string key="NSClassName">SRRecorderControl</string>
 						</object>
+						<object class="NSButton" id="293850217">
+							<reference key="NSNextResponder" ref="579521538"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{72, 28}, {288, 32}}</string>
+							<reference key="NSSuperview" ref="579521538"/>
+							<reference key="NSNextKeyView"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSButtonCell" key="NSCell" id="607983071">
+								<int key="NSCellFlags">67108864</int>
+								<int key="NSCellFlags2">134217728</int>
+								<string key="NSContents"/>
+								<reference key="NSSupport" ref="473291212"/>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<reference key="NSControlView" ref="293850217"/>
+								<int key="NSButtonFlags">-2038284288</int>
+								<int key="NSButtonFlags2">129</int>
+								<string key="NSAlternateContents"/>
+								<string key="NSKeyEquivalent"/>
+								<int key="NSPeriodicDelay">200</int>
+								<int key="NSPeriodicInterval">25</int>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
 					</array>
-					<string key="NSFrameSize">{378, 272}</string>
+					<string key="NSFrameSize">{378, 329}</string>
 					<reference key="NSSuperview"/>
-					<reference key="NSWindow"/>
 					<reference key="NSNextKeyView" ref="673984933"/>
 					<string key="NSReuseIdentifierKey">_NS:2836</string>
 				</object>
-				<string key="NSScreenRect">{{-1920, 57}, {1920, 1080}}</string>
+				<string key="NSScreenRect">{{-1440, -102}, {1440, 900}}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<bool key="NSWindowIsRestorable">YES</bool>
 			</object>
 			<object class="NSTextField" id="549068278">
-				<nil key="NSNextResponder"/>
+				<reference key="NSNextResponder"/>
 				<int key="NSvFlags">268</int>
 				<string key="NSFrameSize">{90, 17}</string>
+				<reference key="NSSuperview"/>
+				<reference key="NSNextKeyView"/>
 				<string key="NSReuseIdentifierKey">_NS:3935</string>
 				<bool key="NSEnabled">YES</bool>
 				<object class="NSTextFieldCell" key="NSCell" id="515372387">
@@ -457,9 +515,11 @@
 				<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 			</object>
 			<object class="NSTextField" id="987644109">
-				<nil key="NSNextResponder"/>
+				<reference key="NSNextResponder"/>
 				<int key="NSvFlags">268</int>
 				<string key="NSFrameSize">{97, 17}</string>
+				<reference key="NSSuperview"/>
+				<reference key="NSNextKeyView"/>
 				<string key="NSReuseIdentifierKey">_NS:3935</string>
 				<bool key="NSEnabled">YES</bool>
 				<object class="NSTextFieldCell" key="NSCell" id="890184422">
@@ -543,6 +603,22 @@
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
+						<string key="label">palettePicker</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="293850217"/>
+					</object>
+					<int key="connectionID">73</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">paletteFileOpener:</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="293850217"/>
+					</object>
+					<int key="connectionID">75</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
 						<string key="label">delegate</string>
 						<reference key="source" ref="621850563"/>
 						<reference key="destination" ref="1001"/>
@@ -599,6 +675,9 @@
 							<reference ref="139660187"/>
 							<reference ref="670204656"/>
 							<reference ref="621850563"/>
+							<reference ref="452078279"/>
+							<reference ref="740933624"/>
+							<reference ref="293850217"/>
 						</array>
 						<reference key="parent" ref="638456603"/>
 					</object>
@@ -799,6 +878,37 @@
 						<reference key="object" ref="739444344"/>
 						<reference key="parent" ref="494084656"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">60</int>
+						<reference key="object" ref="293850217"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="607983071"/>
+						</array>
+						<reference key="parent" ref="579521538"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">61</int>
+						<reference key="object" ref="607983071"/>
+						<reference key="parent" ref="293850217"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">62</int>
+						<reference key="object" ref="452078279"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="957168895"/>
+						</array>
+						<reference key="parent" ref="579521538"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">63</int>
+						<reference key="object" ref="740933624"/>
+						<reference key="parent" ref="579521538"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">64</int>
+						<reference key="object" ref="957168895"/>
+						<reference key="parent" ref="452078279"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -841,79 +951,19 @@
 				<string key="54.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="55.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="59.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="60.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="61.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="62.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="63.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="64.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 			</dictionary>
 			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">59</int>
+			<int key="maxID">75</int>
 		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">PreferencesController</string>
-					<string key="superclassName">NSWindowController</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">controllerChanged:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">controllerChanged:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">controllerChanged:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<dictionary class="NSMutableDictionary" key="outlets">
-						<string key="defaultFormat">NSPopUpButton</string>
-						<string key="openAtLogin">NSButton</string>
-						<string key="recorderView">SRRecorderControl</string>
-						<string key="showColorPreview">NSButton</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<object class="IBToOneOutletInfo" key="defaultFormat">
-							<string key="name">defaultFormat</string>
-							<string key="candidateClassName">NSPopUpButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="openAtLogin">
-							<string key="name">openAtLogin</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="recorderView">
-							<string key="name">recorderView</string>
-							<string key="candidateClassName">SRRecorderControl</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="showColorPreview">
-							<string key="name">showColorPreview</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/PreferencesController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">SRRecorderControl</string>
-					<string key="superclassName">NSControl</string>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">delegate</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">delegate</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">delegate</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/SRRecorderControl.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes"/>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>


### PR DESCRIPTION
I added this functionality at a basic level to your app. It reads a palette color file (for now only in .less format) and in the color preview panel shows the name of the hovered color of it matches one of the colors in the palette.

It's useful for developers who work with screen files from designers and want detect color names used on a png. Or vice versa.
![screen shot 2013-06-04 at 4 24 11 pm](https://f.cloud.github.com/assets/234060/606008/828b7a6c-cd22-11e2-8466-c377172f34d8.png)
